### PR TITLE
Fix row not found in distributed environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql-pg-subscriptions",
-  "version": "3.1.2",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql-pg-subscriptions",
-      "version": "3.1.2",
+      "version": "3.2.6",
       "license": "ISC",
       "dependencies": {
         "graphql-subscriptions": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-pg-subscriptions",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "A graphql subscriptions implementation using postgres and apollo's graphql-subscriptions.",
   "homepage": "https://github.com/siamahnaf/graphql-pg-subscriptions",
   "main": "dist/cjs/index.js",

--- a/src/pubsub/event-emitter-to-async-iterator.ts
+++ b/src/pubsub/event-emitter-to-async-iterator.ts
@@ -18,6 +18,12 @@ function eventEmitterAsyncIterator<T>(
     const pushValue = async ({ payload: event }: { payload: T }) => {
         const query = `SELECT payload FROM pubsub_payloads WHERE id = $1`;
         const res = await client.query(query, [event]);
+
+        if (res.rows.length === 0) {
+            // Event was already processed and deleted by another consumer
+            return;
+        }
+
         const value = commonMessageHandler(res.rows[0].payload);
         if (pullQueue.length !== 0) {
             pullQueue.shift()!({ value, done: false });


### PR DESCRIPTION
We have 2 containers behind a load balancer that can receive subscriptions. When both of them have subscriptions, one may delete the row first and then the other won't find the event. This was causing many `unhandledRejection` to be thrown.